### PR TITLE
支持跨线程推理，强制对所有实例进行unload再finalize

### DIFF
--- a/axengine/_axclrt.py
+++ b/axengine/_axclrt.py
@@ -139,6 +139,11 @@ class AXCLRTSession(Session):
         self.soc_name = axclrt_cffi.string(axclrt_lib.axclrtGetSocName()).decode()
         print(f"[INFO] SOC Name: {self.soc_name}")
 
+        self._thread_context = axclrt_cffi.new("axclrtContext *")
+        ret = axclrt_lib.axclrtGetCurrentContext(self._thread_context)
+        if ret != 0:
+            raise RuntimeError("axclrtGetCurrentContext failed")
+
         # model handle, context, info, io
         self._model_id = axclrt_cffi.new("uint64_t *")
         self._context_id = axclrt_cffi.new("uint64_t *")
@@ -321,6 +326,10 @@ class AXCLRTSession(Session):
     ):
         self._validate_input(input_feed)
         self._validate_output(output_names)
+
+        ret = axclrt_lib.axclrtSetCurrentContext(self._thread_context[0])
+        if ret != 0:
+            raise RuntimeError("axclrtSetCurrentContext failed")
 
         if None is output_names:
             output_names = [o.name for o in self.get_outputs()]


### PR DESCRIPTION
1. [适配新代码，利用axclrtSetDevice完成context的get/set，从而支持跨线程推理](https://github.com/AXERA-TECH/pyaxengine/pull/21/commits/2ce8f873767962f32484d1eff567195f0b65888c)
2. [创建模型实例会添加目前实例到全局变量，程序退出时，先对所有实例进行unload再finalize](https://github.com/AXERA-TECH/pyaxengine/pull/21/commits/a4c757c2a8f2faee2187ee22840c1f6e58700f83)