### PR TITLE
Output Name Error on _axclrt.py

### DIFF
--- a/axengine/_axclrt.py
+++ b/axengine/_axclrt.py
@@ -276,7 +276,8 @@ class AXCLRTSession(Session):
         for group in range(self._shape_count):
             one_group_io = []
             for index in range(axclrt_lib.axclrtEngineGetNumOutputs(self._info[0])):
-                name = axclrt_lib.axclrtEngineGetOutputNameByIndex(self._info[0], index)
+                cffi_name  = axclrt_lib.axclrtEngineGetOutputNameByIndex(self._info[0], index)
+                name = axclrt_cffi.string(cffi_name).decode("utf-8")
 
                 cffi_dtype = axclrt_cffi.new("axclrtEngineDataType *")
                 ret = axclrt_lib.axclrtEngineGetOutputDataType(self._info[0], index, cffi_dtype)


### PR DESCRIPTION
https://github.com/AXERA-TECH/pyaxengine/issues/35

Current code assigns C pointers directly to name, displaying addresses instead of values. Solution: Store pointer in cffi_name, then convert using axclrt_cffi.string().decode("utf-8"). This properly converts C strings to Python strings, matching the approach in _get_inputs().

Before change:

axengine/_axclrt.py LineNo.279

name = axclrt_lib.axclrtEngineGetOutputNameByIndex(self._info[0], index) After change:

axengine/_axclrt.py LineNo.279

cffi_name = axclrt_lib.axclrtEngineGetOutputNameByIndex(self._info[0], index) name = axclrt_cffi.string(cffi_name).decode("utf-8")