### PR TITLE
Fix duplicate memory usage when loading model

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ root@ax650:~/samples# python3 classification.py -m /opt/data/npu/models/mobilene
 
 - [zylo117](https://github.com/zylo117): 提供了基于 cffi 的 AXCL Runtime Python API 实现
 - [nnn](https://github.com/nnn112358)，[HongJie Li](https://github.com/techshoww) 和 [Shinichi Tanaka](https://github.com/s1tnk) 报告 cffi 的使用问题，[Shinichi Tanaka](https://github.com/s1tnk) 提供了解决方案
-
+- [yuyun](https://github.com/yuyun2000): 修复了加载模型时会在系统内存重复占用内存的bug
 
 ## 关联项目
 


### PR DESCRIPTION
Resolve issue where loading a model creates an extra copy in system memory, causing redundant memory consumption.Look at `https://github.com/yuyun2000/m5log/blob/main/%E6%8A%80%E5%B7%A7%E7%9B%B8%E5%85%B3/650-python%E5%8C%85%E5%86%85%E5%AD%98%E5%A4%8D%E5%88%B6.md`