### PR TITLE
fix set outputs names

### DIFF
--- a/axengine/_axclrt.py
+++ b/axengine/_axclrt.py
@@ -372,8 +372,10 @@ class AXCLRTSession(Session):
 
         # get output
         outputs = []
+        origin_output_names = [_o.name for _o in self.get_outputs(shape_group)]
+        outputs_ranks = [output_names.index(_on) for _on in origin_output_names]
         if 0 == ret:
-            for i in range(len(self.get_outputs(shape_group))):
+            for i in outputs_ranks:
                 ret = axclrt_lib.axclrtEngineGetOutputBufferByIndex(self._io[0], i, dev_prt, dev_size)
                 if 0 != ret:
                     raise RuntimeError(f"axclrtEngineGetOutputBufferByIndex failed for output {i}.")

--- a/axengine/_axe.py
+++ b/axengine/_axe.py
@@ -397,7 +397,6 @@ class AXEngineSession(Session):
         outputs = []
         origin_output_names = [_o.name for _o in self.get_outputs(shape_group)]
         outputs_ranks = [output_names.index(_on) for _on in origin_output_names]
-
         if 0 == ret:
             for i in outputs_ranks:
                 sys_lib.AX_SYS_MinvalidateCache(

--- a/axengine/_axe.py
+++ b/axengine/_axe.py
@@ -395,8 +395,11 @@ class AXEngineSession(Session):
 
         # flush output
         outputs = []
+        origin_output_names = [_o.name for _o in self.get_outputs(shape_group)]
+        outputs_ranks = [output_names.index(_on) for _on in origin_output_names]
+
         if 0 == ret:
-            for i in range(len(self.get_outputs(shape_group))):
+            for i in outputs_ranks:
                 sys_lib.AX_SYS_MinvalidateCache(
                     self._io[0].pOutputs[i].phyAddr,
                     self._io[0].pOutputs[i].pVirAddr,


### PR DESCRIPTION
supports set outputs ranks in axe.session.run(), the behavior is the same with ort.
